### PR TITLE
add support of getting ip from ip138 && last ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ arDdnsCheck "test.org" "subdomain"
 ```
 
 # 最近更新
+2019/05/16
+- 增加public Ip获取方式，包括
+  - [api.ipify.org](https://api.ipify.org)
+  - [ipapi.co](https://ipapi.co/)
+  - [seeip.ort](https://ip4.seeip.org)
+  - [api.myip.com](https://api.myip.com)
+  - [ifconfig.co](https://ifconfig.co)
+- 支持随机选择public IP获取方式，如果失效会自动重试随机选择
+- 为支持随机选择，切换环境，从/bin/sh 到 /bin/bash
 
 2015/2/24
 - 增加token鉴权方式 (by wbchn)

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -23,6 +23,10 @@ case $(uname) in
         # echo $extip
 
 	if [ "x${WanIp}" = "x" ]; then
+		WanIp=`curl -s https://ipinfo.io | grep ip |sed 's/.*ip": "\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+	fi
+
+	if [ "x${WanIp}" = "x" ]; then
 		WanIp=`curl -s -d "ip=myip" http://ip.taobao.com/service/getIpInfo2.php  |  sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
 	fi
 	

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #################################################
 # AnripDdns v5.08
@@ -32,12 +32,8 @@ function getPublicIp() {
             WanIp=`curl -s 'https://api.myip.com' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
             echo $WanIp
             ;;
-        6)
-            WanIp=`curl -s 'https://ifconfig.co'`
-            echo $WanIp
-            ;;
         *)
-            WanIp=`curl -s 'http://api.ipstack.com/114.253.244.139?access_key=62510fcf15eec61119dc63b73296dd27&format=0&fields=ip' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            WanIp=`curl -s 'https://ifconfig.co'`
             echo $WanIp
             ;;
     esac
@@ -56,7 +52,7 @@ case $(uname) in
         # echo $extip
 
 	if [ "x${WanIp}" = "x" ]; then
-		Index=$(( $RANDOM % 7))
+		Index=$(( $RANDOM % 6))
 		WanIp=$(getPublicIp $Index)
 	fi
 

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -21,9 +21,13 @@ case $(uname) in
 	#         extip=$(ip -o -4 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4}' | cut -d/ -f1 )
         # fi
         # echo $extip
+
+	if [ "x${WanIp}" = "x" ]; then
+		WanIp=`curl -s -d "ip=myip" http://ip.taobao.com/service/getIpInfo2.php  |  sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+	fi
 	
 	if [ "x${WanIp}" = "x" ]; then
-		WanIp=`curl http://city.ip138.com/ip2city.asp | grep center | sed 's/.*\[\([0-9\.]*\)\].*/\1/g' `
+		WanIp=`curl -s http://city.ip138.com/ip2city.asp | grep center | sed 's/.*\[\([0-9\.]*\)\].*/\1/g' `
 	fi
 	echo $WanIp
     }
@@ -204,3 +208,9 @@ arDdnsCheck() {
 
 date
 . $DIR/dns.conf
+
+echo ""
+echo ""
+echo ""
+echo "+++++++++++++++++++++++++++"
+

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -10,6 +10,39 @@
 WanIp=""
 LastIpFile=last.ip
 
+function getPublicIp() {
+    case $1 in
+        1)
+            WanIp=`curl -s 'https://api.ipify.org?format=json' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        2)
+            WanIp=`curl -s 'https://ipapi.co/ip/'`
+            echo $WanIp
+            ;;
+        3)
+            WanIp=`curl -s 'http://ip-api.com/json/?fields=query' | grep query |sed 's/.*query":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        4)
+            WanIp=`curl -s 'https://ip4.seeip.org'`
+            echo $WanIp
+            ;;
+        5)
+            WanIp=`curl -s 'https://api.myip.com' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        6)
+            WanIp=`curl -s 'https://ifconfig.co'`
+            echo $WanIp
+            ;;
+        *)
+            WanIp=`curl -s 'http://api.ipstack.com/114.253.244.139?access_key=62510fcf15eec61119dc63b73296dd27&format=0&fields=ip' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+    esac
+}
+
 # OS Detection
 case $(uname) in
   'Linux')
@@ -23,19 +56,23 @@ case $(uname) in
         # echo $extip
 
 	if [ "x${WanIp}" = "x" ]; then
-		WanIp=`curl -s 'https://api.ipify.org?format=json' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+		Index=$(( $RANDOM % 7))
+		WanIp=$(getPublicIp $Index)
 	fi
 
 	if [ "x${WanIp}" = "x" ]; then
-		WanIp=`curl -s https://ipinfo.io | grep ip |sed 's/.*ip": "\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+		Index=$(( $RANDOM % 6))
+		WanIp=$(getPublicIp $Index)
 	fi
 
 	if [ "x${WanIp}" = "x" ]; then
-		WanIp=`curl -s -d "ip=myip" http://ip.taobao.com/service/getIpInfo2.php  |  sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+		Index=$(( $RANDOM % 6))
+		WanIp=$(getPublicIp $Index)
 	fi
 	
 	if [ "x${WanIp}" = "x" ]; then
-		WanIp=`curl -s http://city.ip138.com/ip2city.asp | grep center | sed 's/.*\[\([0-9\.]*\)\].*/\1/g' `
+		Index=$(( $RANDOM % 6))
+		WanIp=$(getPublicIp $Index)
 	fi
 	echo $WanIp
     }

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -23,6 +23,10 @@ case $(uname) in
         # echo $extip
 
 	if [ "x${WanIp}" = "x" ]; then
+		WanIp=`curl -s 'https://api.ipify.org?format=json' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+	fi
+
+	if [ "x${WanIp}" = "x" ]; then
 		WanIp=`curl -s https://ipinfo.io | grep ip |sed 's/.*ip": "\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
 	fi
 

--- a/getPublicIp.sh
+++ b/getPublicIp.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function getPublicIp() {
+    case $1 in
+        1)
+            WanIp=`curl -s 'https://api.ipify.org?format=json' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        2)
+            WanIp=`curl -s 'https://ipapi.co/ip/'`
+            echo $WanIp
+            ;;
+        3)
+            WanIp=`curl -s 'http://ip-api.com/json/?fields=query' | grep query |sed 's/.*query":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        4)
+            WanIp=`curl -s 'https://ip4.seeip.org'`
+            echo $WanIp
+            ;;
+        5)
+            WanIp=`curl -s 'https://api.myip.com' | grep ip |sed 's/.*ip":"\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)".*/\1/g'`
+            echo $WanIp
+            ;;
+        *)
+            WanIp=`curl -s 'https://ifconfig.co'`
+            echo $WanIp
+            ;;
+    esac
+}
+
+# Index=$(( $RANDOM % 7))
+Index=$1
+WanIp=$(getPublicIp $Index)
+echo "get WanIp from" $Index ":"$WanIp


### PR DESCRIPTION
1. most of cases around cannot get their IPs of Internet from network cards directly. It should be more  convenient to use a public service here such as ip138 or ip.taobao.com.

2. record of last ip can be useful to reduce the frequency of request to dnspod.