### PR TITLE
修复 arDdnsRecordIp 中 ipv6 判断问题

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -170,7 +170,7 @@ arDdnsRecordIp() {
 
     # Output Record Ip
     case "$recordIp" in
-        [1-9]*)
+        [0-9a-fA-F]*)
             echo $recordIp
             return 0
         ;;


### PR DESCRIPTION
Resolves https://github.com/rehiy/dnspod-shell/issues/76