### PR TITLE
排除IPV6中的本地网络地址

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -69,7 +69,7 @@ arWanIp6() {
 
     local hostIp
 
-    local lanIps="(^$)|(^::1$)|(^fe[8-9,A-F])"
+    local lanIps="(^$)|(^::1$)|(^f)"
 
     case $(uname) in
         'Linux')


### PR DESCRIPTION
根据RFC4193，FD00::/8属于本地网络地址，例如openwrt默认会分配fd34前缀。
这里直接排除掉所有f开头的ipv6地址。以防止提交本地网络的IP。