### PR TITLE
支持ipv6的::1 或者 fd2c:2ef:94bd::645a 这样的数据

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -73,7 +73,7 @@ arWanIp6() {
 
     case $(uname) in
         'Linux')
-            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4}' | cut -d/ -f1 | grep -Ev "$lanIps" | tail -n 1)
+            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4}' | cut -d/ -f1 | grep -Ev "$lanIps" | head -n 1)
         ;;
         'Darwin')
             hostIp=$(ifconfig | grep "inet6 " | awk '{print $2}' | grep -Ev "$lanIps" | tail -n 1)
@@ -168,7 +168,7 @@ arDdnsRecordIp() {
 
     # Output Record Ip
     case "$recordIp" in
-        [1-9]*)
+        [0-9abcdef:]*)
             echo $recordIp
             return 0
         ;;


### PR DESCRIPTION
支持ipv6的::1 或者 fd2c:2ef:94bd::645a 这样的数据
另外 我的pve 和 dsm都是取第一个ipv6地址比较合适，所以tail改成了head