### PR TITLE
优先选择剩余时间最长的ipv6地址

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -73,7 +73,7 @@ arWanIp6() {
 
     case $(uname) in
         'Linux')
-            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4}' | cut -d/ -f1 | grep -Ev "$lanIps" | tail -n 1)
+            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' |awk '{print $4,substr($NF,0,length($NF)-3)}'|sed 's/fore/2592000/g'|sort -k 2 -n | cut -d/ -f1 | grep -Ev "$lanIps" | tail -n 1)
         ;;
         'Darwin')
             hostIp=$(ifconfig | grep "inet6 " | awk '{print $2}' | grep -Ev "$lanIps" | tail -n 1)


### PR DESCRIPTION
按照preferred_lft剩余时间排序
剩余时间为forever的替换成2592000进行处理