### PR TITLE
修复选出的IPv6地址为剩余时间最短的bug，改为剩余时间最长且排除内网ip的IPv6地址。

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -71,9 +71,10 @@ arWanIp6() {
 
     local lanIps="(^$)|(^::1$)|(^[fF][eE][8-9a-fA-F])"
 
+    # sort指令添加参数-r使得获得最大preferred_lft值的IP， awk '{ if ( length($0) >= 30 ) print $0}'过滤内网IP
     case $(uname) in
         'Linux')
-            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4,substr($NF,0,length($NF)-3)}' | sed 's/fore/2592000/g' | sort -k 2 -n | cut -d/ -f1 | grep -Ev "$lanIps" | head -n 1)
+            hostIp=$(ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4,substr($NF,0,length($NF)-3)}' | sed 's/fore/2592000/g' | sort -k 2 -n -r | cut -d/ -f1 | awk '{ if ( length($0) >= 30 ) print $0}' | grep -Ev "$lanIps" | head -n 1)
         ;;
         Darwin|FreeBSD)
             hostIp=$(ifconfig | grep "inet6 " | awk '{print $2}' | grep -Ev "$lanIps" | head -n 1)


### PR DESCRIPTION
有关IPv6的错误修复：
在我的ubuntu运行时，能够读取到6条IPv6地址，其中一条内网地址（已通过长度排除），另外三条无用的IPv6地址（外网ping不通），还有两条有效的IPv6。根据跟新信息，已经有贡献着优化选择了剩余时间最长的IPv6地址，然鹅并没有奏效。
我调试了它的代码
`ip -o -6 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4,substr($NF,0,length($NF)-3)}' | sed 's/fore/2592000/g' | sort -k 2 -n`
得到了IPv6地址以及它们的 preferred_lft 输出，遗憾的是它们是按从小到大的顺序排列的，并且合理的是，它选出的那条 preferred_lft 为0的地址正是一条失效的地址，而那个数值最大的地址正是有效的地址，所以我加上了-r反转排序，一切似乎奏效了。
