### PR TITLE
增加强制使用第三方API获取IP的选项

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -18,6 +18,10 @@
 
 export arToken=""
 
+# Force to use third party API to get IP or not
+
+export forceUseThirdApi=false
+
 # Get WAN IPv4
 
 arWanIp4() {
@@ -41,7 +45,7 @@ arWanIp4() {
         ;;
     esac
 
-    if [ -z "$hostIp" ]; then
+    if [ -z "$hostIp" -o "$forceUseThirdApi" = true ]; then
         if type wget >/dev/null 2>&1; then
             hostIp=$(wget -q -O- https://v4.myip.la)
         else
@@ -80,7 +84,7 @@ arWanIp6() {
         ;;
     esac
 
-    if [ -z "$hostIp" ]; then
+    if [ -z "$hostIp" -o "$forceUseThirdApi" = true ]; then
         if type wget >/dev/null 2>&1; then
             hostIp=$(wget -q -O- https://v6.myip.la)
         else

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -7,6 +7,9 @@
 # Combine your token ID and token together as follows
 arToken="12345,7676f344eaeaea9074c123451234512d"
 
+# Force to use third party API to get IP or not
+forceUseThirdApi=false
+
 # Place each domain you want to check as follows
 # you can have multiple arDdnsCheck blocks
 


### PR DESCRIPTION
在一些情况下，`IPv6`无法正确获取，获取到的是本地能ping通而公网无法ping通的IP，而使用第三方API的原先前提是本地获取`$hostIp`失败，，因此增加强制使用第三方API获取IP的选项。
