### PR TITLE
Wrap log printing as arLog function to allow user customization

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -16,6 +16,15 @@
 
 export arToken
 
+# Define arLog to output to stderr, if not defined in ddnspod.sh
+
+if ! type arLog >/dev/null 2>&1; then
+    arLog() {
+        >&2 echo $@
+    }
+fi
+
+
 # Get IPv4
 
 arWanIp4() {
@@ -64,12 +73,12 @@ arWanIp6() {
     fi
 
     if [ -z "$hostIp" ]; then
-        echo "> arWanIp6 - Can't get ip address"
+        arLog "> arWanIp6 - Can't get ip address"
         return 1
     fi
 
     if [ -z "$(echo $hostIp | grep -E '^[0-9a-fA-F:]+$')" ]; then
-        echo "> arWanIp6 - Invalid ip address"
+        arLog "> arWanIp6 - Invalid ip address"
         return 1
     fi
 
@@ -110,7 +119,7 @@ arDdnsLookup() {
 
     if ! [ "$recordId" -gt 0 ] 2>/dev/null ;then
         errMsg=$(echo $recordId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
-        echo "> arDdnsLookup - $errMsg"
+        arLog "> arDdnsLookup - $errMsg"
         return 1
     fi
 
@@ -140,11 +149,12 @@ arDdnsUpdate() {
     recordIp=$(echo $recordRs | sed 's/.*,"value":"\([0-9a-fA-F\.\:]*\)".*/\1/')
 
     if [ "$recordCd" = "1" ]; then
-        echo "> arDdnsUpdate - $recordIp"
+        arLog "> arDdnsUpdate - $recordIp"
+        echo $recordIp
         return 0
     else
         errMsg=$(echo $recordRs | sed 's/.*,"message":"\([^"]*\)".*/\1/')
-        echo "> arDdnsUpdate - $errMsg"
+        arLog "> arDdnsUpdate - $errMsg"
         return 1
     fi
 
@@ -160,42 +170,42 @@ arDdnsCheck() {
     local recordId
     local recordType
 
-    echo "=== Check $2.$1 ==="
-    echo "Fetching Host Ip"
+    arLog "=== Check $2.$1 ==="
+    arLog "Fetching Host Ip"
 
     if [ "$3" = "6" ]; then
         recordType=AAAA
         hostIp=$(arWanIp6)
         if [ $? -ne 0 ]; then
-            echo $hostIp
+            arLog $hostIp
             return 1
         else
-            echo "> Host Ip: $hostIp"
-            echo "> Record Type: $recordType"
+            arLog "> Host Ip: $hostIp"
+            arLog "> Record Type: $recordType"
         fi
     else
         recordType=A
         hostIp=$(arWanIp4)
         if [ $? -ne 0 ]; then
-            echo "> Host Ip: Auto"
-            echo "> Record Type: $recordType"
+            arLog "> Host Ip: Auto"
+            arLog "> Record Type: $recordType"
         else
-            echo "> Host Ip: $hostIp"
-            echo "> Record Type: $recordType"
+            arLog "> Host Ip: $hostIp"
+            arLog "> Record Type: $recordType"
         fi
     fi
 
-    echo "Fetching RecordId"
+    arLog "Fetching RecordId"
     recordId=$(arDdnsLookup "$1" "$2" "$recordType")
 
     if [ $? -ne 0 ]; then
-        echo $recordId
+        arLog $recordId
         return 1
     else
-        echo "> Record Id: $recordId"
+        arLog "> Record Id: $recordId"
     fi
 
-    echo "Updating Record value"
+    arLog "Updating Record value"
     arDdnsUpdate "$1" "$2" "$recordId" "$recordType" "$hostIp"
 
 }


### PR DESCRIPTION
在客制化使用dnspod-shell的过程中，可能会遇到以下两个需求：
1) 提取执行ardnspod后返回的record ip，进行后续的定制化处理。此时相对于不规则且可能随时修改的日志格式，直接输出record ip会更好一些；
2) 将日志以某种统一的方式打印。如在华硕路由器中，我们可能希望DDNS的日志统一打印在“系统记录”中，方便在管理界面统一查看。

对于需求1，我们可以将日志输出到stderr中，同时将record ip输出到stdout中，从而执行`$(arDdnsCheck)`后，得到的就是最终的record ip。

对于需求2，华硕提供了`logger`命令以向“系统记录”中写日志。因此，如果我们能向ardnspod提供定制的日志函数，即可让其输出到指定的“系统记录”位置。

结合以上两点需求，我们可以定义一个`arLog`接口。该接口默认定义为向stderr中进行echo。此时，若在`ddnspod.sh`中定义自己的`arLog`函数，则`ardnspod`将不使用默认的实现，而转而使用用户提供的实现，从而达成目标。

