### PR TITLE
Distinguish record ip unchanged event from updated event

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -24,6 +24,11 @@ if ! type arLog >/dev/null 2>&1; then
     }
 fi
 
+# The error code to return when a ddns record is not changed
+
+if [ -z "$arErrCodeUnchanged" ]; then
+    arErrCodeUnchanged=0 # By default, report unchanged event as success
+fi
 
 # Get IPv4
 
@@ -133,9 +138,25 @@ arDdnsUpdate() {
 
     local errMsg
 
+    local lastRecordIp
     local recordRs
     local recordCd
     local recordIp
+
+    # if code for unchanged event is specified to be different from updated event, we fetch the last record ip
+    if [ $arErrCodeUnchanged -ne 0 ]; then
+        recordRs=$(arDdnsApi "Record.Info" "domain=$1&record_id=$3")
+        recordCd=$(echo $recordRs | sed 's/.*{"code":"\([0-9]*\)".*/\1/')
+        lastRecordIp=$(echo $recordRs | sed 's/.*,"value":"\([0-9a-fA-F\.\:]*\)".*/\1/')
+
+        if [ "$recordCd" != "1" ]; then
+            errMsg=$(echo $recordRs | sed 's/.*,"message":"\([^"]*\)".*/\1/')
+            arLog "> arDdnsUpdate - error: $errMsg"
+            return 1
+        else
+            arLog "> arDdnsUpdate - last record ip: $lastRecordIp"
+        fi
+    fi
 
     # update ip
     if [ -z "$5" ]; then
@@ -148,14 +169,22 @@ arDdnsUpdate() {
     recordCd=$(echo $recordRs | sed 's/.*{"code":"\([0-9]*\)".*/\1/')
     recordIp=$(echo $recordRs | sed 's/.*,"value":"\([0-9a-fA-F\.\:]*\)".*/\1/')
 
-    if [ "$recordCd" = "1" ]; then
-        arLog "> arDdnsUpdate - $recordIp"
+    if [ "$recordCd" != "1" ]; then
+        errMsg=$(echo $recordRs | sed 's/.*,"message":"\([^"]*\)".*/\1/')
+        arLog "> arDdnsUpdate - error: $errMsg"
+        return 1
+    elif [ $arErrCodeUnchanged -eq 0 ]; then
+        arLog "> arDdnsUpdate - success: $recordIp" # both unchanged and updated event
         echo $recordIp
         return 0
+    elif [ "$recordIp" = "$lastRecordIp" ]; then
+        arLog "> arDdnsUpdate - unchanged: $recordIp" # unchanged event
+        echo $recordIp
+        return $arErrCodeUnchanged
     else
-        errMsg=$(echo $recordRs | sed 's/.*,"message":"\([^"]*\)".*/\1/')
-        arLog "> arDdnsUpdate - $errMsg"
-        return 1
+        arLog "> arDdnsUpdate - updated: $recordIp" # updated event
+        echo $recordIp
+        return 0
     fi
 
 }

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -7,6 +7,10 @@
 # Combine your token ID and token together as follows
 arToken="12345,7676f344eaeaea9074c123451234512d"
 
+# Return code when the last record IP is same as current host IP
+# Set this to a value other than 0 to distinguish with a successful ddns update
+# arErrCodeUnchanged=0
+
 # Place each domain you want to check as follows
 # you can have multiple arDdnsCheck blocks
 


### PR DESCRIPTION
在客制化使用dnspod-shell的过程中，我们很可能需要将DDNS的1）**成功更新IP**，与2）**IP与dns记录相同，无改动** 作为两个事件分开处理。

以华硕路由器的ddns hook脚本为例。该脚本会每隔一段时间执行一次，并且若脚本报告更新失败，会在很短的时间内立即重新执行一次。因此我们对DDNS事件的处理方案是：
* 成功更新IP：**根据新记录IP执行后续hook逻辑**，并向华硕路由器报告成功；
* IP无改动：**不执行后续hook逻辑（因为对使用该域名的用户来说，没有任何变化，不应该每隔几十分钟就重新执行一次hook逻辑）**，并向华硕路由器报告成功；
* 出错：打印错误，向华硕路由器报告失败。

因此，不管是最初的将IP未改变作为错误处理（return 1），还是经 https://github.com/rehiy/dnspod-shell/issues/63 之后的作为成功处理（return 0），都是不合适的。但是对于不需要对IP未改变情况特殊处理的用户，强制要求其处理也是不合适的（如return 2）。

综上，我们可以将“IP记录未改变”时的返回码作为配置显式定义，允许用户在`ddnspod.sh`进行显式修改。默认情况下，该返回码为0，从而作为成功情况报告。