### PR TITLE
Retrieve outbound interface ip by `ip route get`

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -38,10 +38,12 @@ arWanIp4() {
     lanIps="$lanIps|(^169\.254\.[0-9]{1,3}\.[0-9]{1,3}$)"
     lanIps="$lanIps|(^172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]{1,3}\.[0-9]{1,3}$)"
     lanIps="$lanIps|(^192\.168\.[0-9]{1,3}\.[0-9]{1,3}$)"
+    lanIps="$lanIps|(^100\.(6[4-9]|[7-9][0-9])\.[0-9]{1,3}\.[0-9]{1,3}$)"  # 100.64.x.x - 100.99.x.x
+    lanIps="$lanIps|(^100\.1([0-1][0-9]|2[0-7])\.[0-9]{1,3}\.[0-9]{1,3}$)" # 100.100.x.x - 100.127.x.x
 
     case $(uname) in
         'Linux')
-            hostIp=$(ip -o -4 addr list | grep -Ev '\s(docker|lo)' | awk '{print $4}' | cut -d/ -f1 | grep -Ev "$lanIps")
+            hostIp=$(ip -o -4 route get 100.64.0.1 | grep -oE 'src [0-9\.]+' | awk '{print $2}' | grep -Ev "$lanIps")
         ;;
         Darwin|FreeBSD)
             hostIp=$(ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}' | grep -Ev "$lanIps")
@@ -66,10 +68,20 @@ arWanIp6() {
 
     local hostIp
 
-    if type curl >/dev/null 2>&1; then
-        hostIp=$(curl -s 6.ipw.cn)
-    else
-        hostIp=$(wget -q -O- 6.ipw.cn)
+    local lanIps="(^$)|(^::1$)|(^fe[8-9,A-F])"
+
+    case $(uname) in
+        'Linux')
+            hostIp=$(ip -o -6 route get 100::1 | grep -oE 'src [0-9a-fA-F:]+' | awk '{print $2}' | grep -Ev "$lanIps")
+        ;;
+    esac
+
+    if [ -z "$hostIp" ]; then
+        if type curl >/dev/null 2>&1; then
+            hostIp=$(curl -s 6.ipw.cn)
+        else
+            hostIp=$(wget -q -O- 6.ipw.cn)
+        fi
     fi
 
     if [ -z "$hostIp" ]; then


### PR DESCRIPTION
https://github.com/rehiy/dnspod-shell/pull/95 与 https://github.com/rehiy/dnspod-shell/pull/96 都谈到了从接口上获取的IPv6地址无法从外部访问的问题。这个问题是因为接口上获取的IPv6地址不一定是真正用于访问公网的地址（并且可能过期了），因而 https://github.com/rehiy/dnspod-shell/commit/909ca43215f08d79eb412d265b8462ffc5f0086d 直接取消了从接口上获取IPv6地址，使用外部的服务器来获取地址。

但实际上`iproute2`是有手段用于知晓对外发送请求时，使用的源地址是什么的：`ip route get`。

以下是IPv6情况下的路由输出：
```sh
$ ip -o -6 route get 100::1
100::1 via fe80::ce1a:faff:fee8:46e0 dev ppp0 src 240e:xxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxx metric 0 hoplimit 64 pref medium
```
其中`src xxx`字段描述的IPv6地址即为主机用于对外沟通的IPv6地址，与`curl ipv6.xxx.xx`所返回的地址结果相同。

考虑到目前commit中，查询ipv6地址的网站`v6.ip.sb`已经失效了（域名直接无法解析了），直接使得IPv6更新失败，因此保留从接口获取地址的能力仍然是很有必要的。

IPv4下也能使用这种方法获得出口IP：
```sh
$ ip -o -4 route get 100.64.0.1
100.64.0.1 via 27.y.y.y dev ppp0 src 27.x.x.x \    cache
```

获取的`27.x.x.x`即为公网ip。对于内网ip：

```sh
$ ip -o -4 route get 100.64.0.1
100.64.0.1 via 10.y.y.1 dev ppp0  src 10.x.x.x \    cache
```
通过`grep -Ev "$lanIps"`，即可将其过滤掉。