### PR TITLE
Allow url for querying public ipv6 address to be configurable

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -24,6 +24,12 @@ if ! type arLog >/dev/null 2>&1; then
     }
 fi
 
+# The url to be used for querying public ipv6 address. We set a default here.
+
+if [ -z "$arIp6QueryUrl" ]; then
+    arIp6QueryUrl="https://6.ipw.cn"
+fi
+
 # The error code to return when a ddns record is not changed
 
 if [ -z "$arErrCodeUnchanged" ]; then
@@ -83,9 +89,9 @@ arWanIp6() {
 
     if [ -z "$hostIp" ]; then
         if type curl >/dev/null 2>&1; then
-            hostIp=$(curl -s 6.ipw.cn)
+            hostIp=$(curl -6 -s $arIp6QueryUrl)
         else
-            hostIp=$(wget -q -O- 6.ipw.cn)
+            hostIp=$(wget -6 -q -O- $arIp6QueryUrl)
         fi
     fi
 

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -7,6 +7,10 @@
 # Combine your token ID and token together as follows
 arToken="12345,7676f344eaeaea9074c123451234512d"
 
+# Web endpoint to be used for querying the public IPv6 address
+# Set this to override the default url provided by ardnspod
+# arIp6QueryUrl="https://6.ipw.cn"
+
 # Return code when the last record IP is same as current host IP
 # Set this to a value other than 0 to distinguish with a successful ddns update
 # arErrCodeUnchanged=0


### PR DESCRIPTION
目前commit里使用的IPv6查询地址`v6.ip.sb`已经失效（已经没有解析地址了，见https://mxtoolbox.com/SuperTool.aspx?action=a%3av6.ip.sb&run=toolpage ），因此需要更新。

除了再选择一个可用的地址以外，也应当让用户能够显式指定使用的查询地址，从而根据用户的网络情况选择合适的查询节点。