### PR TITLE
Fix no "-4" and "-6" parameter when using busybox wget

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -90,8 +90,10 @@ arWanIp6() {
     if [ -z "$hostIp" ]; then
         if type curl >/dev/null 2>&1; then
             hostIp=$(curl -6 -s $arIp6QueryUrl)
-        else
+        elif ! wget --help 2>&1 | grep -qs BusyBox; then
             hostIp=$(wget -6 -q -O- $arIp6QueryUrl)
+        else
+            hostIp=$(wget -q -O- $arIp6QueryUrl)
         fi
     fi
 
@@ -121,8 +123,10 @@ arDdnsApi() {
 
     if type curl >/dev/null 2>&1; then
         curl -4 -s -A $agent -d $params $dnsapi
-    else
+    elif ! wget --help 2>&1 | grep -qs BusyBox; then
         wget -4 -q -O- --no-check-certificate -U $agent --post-data $params $dnsapi
+    else
+        wget -q -O- --no-check-certificate -U $agent --post-data $params $dnsapi
     fi
 
 }


### PR DESCRIPTION
Busybox提供了wget，且没有"-4"或"-6"参数：
```
~ # wget --help
BusyBox v1.35.0 (2022-05-09 17:27:12 UTC) multi-call binary.

Usage: wget [-cqS] [--spider] [-O FILE] [-o LOGFILE] [--header STR]
        [--post-data STR | --post-file FILE] [-Y on/off]
        [-P DIR] [-U AGENT] [-T SEC] URL...

Retrieve files via HTTP or FTP

        --spider        Only check URL existence: $? is 0 if exists
        --header STR    Add STR (of form 'header: value') to headers
        --post-data STR Send STR using POST method
        --post-file FILE        Send FILE using POST method
        -c              Continue retrieval of aborted transfer
        -q              Quiet
        -P DIR          Save to DIR (default .)
        -S              Show server response
        -T SEC          Network read timeout is SEC seconds
        -O FILE         Save to FILE ('-' for stdout)
        -o LOGFILE      Log messages to FILE
        -U STR          Use STR for User-Agent header
        -Y on/off       Use proxy
```
因此将其作单独处理。