### PR TITLE
Add `-k`(`--insecure`) option to curl in `arDdnsApi`

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -122,7 +122,7 @@ arDdnsApi() {
     local params="login_token=$arToken&format=json&lang=en&$2"
 
     if type curl >/dev/null 2>&1; then
-        curl -4 -s -A $agent -d $params $dnsapi
+        curl -4 -s -k -A $agent -d $params $dnsapi
     elif ! wget --help 2>&1 | grep -qs BusyBox; then
         wget -4 -q -O- --no-check-certificate -U $agent --post-data $params $dnsapi
     else


### PR DESCRIPTION
curl的`-k`选项与wget的`--no-check-certificate`选项相对应，在访问`https://dnsapi.cn`时不进行CA证书检查。

似乎更稳妥的方案是检测一下系统是否有证书仓库，但是#113 里即使有ca-certificates.crt，curl也出问题了……另一种方案是仓库自带一下dnsapi.cn的CA证书，不过似乎BusyBox Wget没有手动指定证书的方案，所以这个PR就先将选项与wget设为一致了。