### PR TITLE
`arRequest`: try to use CA certificates if available

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -51,7 +51,11 @@ arRequest() {
 
     if type curl >/dev/null 2>&1; then
         if echo $url | grep -q https; then
-            params="$params -k"
+            if [ ! -r "/etc/ssl/certs/ca-certificates.crt" ]; then
+                params="$params -k"
+            else
+                params="$params --cacert /etc/ssl/certs/ca-certificates.crt"
+            fi
         fi
         if [ -n "$data" ]; then
             params="$params -d $data"
@@ -62,7 +66,11 @@ arRequest() {
 
     if type wget >/dev/null 2>&1; then
         if echo $url | grep -q https; then
-            params="$params --no-check-certificate"
+            if [ ! -r "/etc/ssl/certs/ca-certificates.crt" ]; then
+                params="$params --no-check-certificate"
+            elif wget --help 2>&1 | grep -qs "GNU Wget"; then
+                params="$params --ca-certificate /etc/ssl/certs/ca-certificates.crt"
+            fi
         fi
         if [ -n "$data" ]; then
             params="$params --post-data $data"

--- a/ardnspod
+++ b/ardnspod
@@ -21,6 +21,9 @@ export arToken
 
 export arIp6QueryUrl="http://ipv6.rpc.im/ip"
 
+# Colon-separated paths to CA certificates for validation in an HTTPs request.
+export arCaCertificates="/etc/ssl/certs/ca-certificates.crt:/opt/etc/ssl/certs/ca-certificates.crt"
+
 # The error code to return when a ddns record is not changed
 # By default, report unchanged event as success
 
@@ -49,12 +52,14 @@ arRequest() {
     local params=""
     local agent="AnripDdns/6.3.0(wang@rehiy.com)"
 
+    local cacert=$(echo "$arCaCertificates" | tr ':' '\n' | xargs -I{} sh -c '[ -r {} ] && echo {}' 2>/dev/null | head -n 1)
+
     if type curl >/dev/null 2>&1; then
-        if echo $url | grep -q https; then
-            if [ ! -r "/etc/ssl/certs/ca-certificates.crt" ]; then
+        if echo $url | grep -q ^https; then
+            if [ -z "$cacert" ]; then
                 params="$params -k"
             else
-                params="$params --cacert /etc/ssl/certs/ca-certificates.crt"
+                params="$params --cacert $cacert"
             fi
         fi
         if [ -n "$data" ]; then
@@ -65,11 +70,11 @@ arRequest() {
     fi
 
     if type wget >/dev/null 2>&1; then
-        if echo $url | grep -q https; then
-            if [ ! -r "/etc/ssl/certs/ca-certificates.crt" ]; then
+        if echo $url | grep -q ^https; then
+            if [ -z "$cacert" ]; then
                 params="$params --no-check-certificate"
             elif wget --help 2>&1 | grep -qs "GNU Wget"; then
-                params="$params --ca-certificate /etc/ssl/certs/ca-certificates.crt"
+                params="$params --ca-certificate $cacert"
             fi
         fi
         if [ -n "$data" ]; then

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -11,6 +11,10 @@ arToken="12345,7676f344eaeaea9074c123451234512d"
 # Set this to override the default url provided by ardnspod
 # arIp6QueryUrl="https://6.ipw.cn"
 
+# CA certificates for validation in an HTTPs request. Multiple paths are colon-separated
+# Set this to provide CA certificates stored in custom location
+# arCaCertificates="/etc/ssl/certs/ca-certificates.crt:/opt/etc/ssl/certs/ca-certificates.crt"
+
 # Return code when the last record IP is same as current host IP
 # Set this to a value other than 0 to distinguish with a successful ddns update
 # arErrCodeUnchanged=0


### PR DESCRIPTION
参考https://github.com/rehiy/dnspod-shell/issues/113 ，我们可以通过检测`/etc/ssl/certs/ca-certificates.crt`文件的存在，自动添加显式指定该证书文件的参数。

当`/etc/ssl/certs/ca-certificates.crt`不存在时：
* 我们将为curl与wget添加`-k`与`--no-check-certificate`参数。
* 某些busybox版wget没有`--no-check-certificate`参数，但是这种版本的wget没有SSL支持，因此本来就无法访问HTTPS URL，因此怎样处理都是会失败的，可以排除考虑。

当`/etc/ssl/certs/ca-certificates.crt`存在时：
* 我们将为curl与gnu wget添加`--cacert`与`--ca-certificate`参数。
* busybox版wget没有`--ca-certificate`参数，因此我们不添加该参数，支持SSL的busybox一般将会自动使用`/etc/ssl/certs/ca-certificates.crt`文件（支持SSL的busybox一般会与ca-certificates包一同安装）。

该PR在`alpine:3.7` (busybox wget， 无ca-certificates)环境中进行了测试，使用的命令为：

* 直接运行ddnspod.sh：
  `wget --no-check-certificate --post-data ...`
* 仅安装GNU Wget：
  `wget --no-check-certificate --post-data ...`
* 仅安装curl（alpine里会连带安装ca-certificates包）：
  `curl --cacert /etc/ssl/certs/ca-certificates.crt -d ...`
* 仅安装ca-certificates：
  `wget --post-data ...`
* 安装GNU Wget + ca-certificates：
  `wget --ca-certificate /etc/ssl/certs/ca-certificates.crt --post-data ...`
  
  