### PR TITLE
修正更新根域名 A 记录(传入 @ 作为 根域名解析记录)无法生效的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ echo "arDdnsCheck test.org subdomain" >> ./ardnspod
 
 # 最近更新
 
+2023/7/22
+
+- Bug fix: 当需要替换根域名时, 如果传入 @ `(如 @.domain.xx)`, 会错误得到 `*.domain.xx` 的结果 `(A记录设置了*的话)`, 导致更新失败. 修改后在传入 `@` 作为子域名时, 直接请求根域名的结果
+
 2023/5/24
 
 - 恢复支持变更检测

--- a/ardnspod
+++ b/ardnspod
@@ -282,8 +282,13 @@ arDdnsLookup() {
 
     local recordId
 
+    if [ "$2" != "@" ]; then
+        # No sub_domain for root domain
+        subDomainRule="&sub_domain=$2"
+    fi
+
     # Get Record Id
-    recordId=$(arDdnsApi "Record.List" "domain=$1&sub_domain=$2&record_type=$3")
+    recordId=$(arDdnsApi "Record.List" "domain=$1${subDomainRule}&record_type=$3")
     recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     if ! [ "$recordId" -gt 0 ] 2>/dev/null ;then


### PR DESCRIPTION
之前是可以的。不知道是不是 dnspod 最近改了规则，当需要替换根域名时, 如果传入 @(如 `@.domain.xx`), 会错误得到 `*.domain.xx` 的结果(A记录设置了*的话), 导致更新失败. 修改后在传入 '@' 作为子域名时, 直接请求根域名的结果

我这边试了一下,  使用  `host @.yourdomain.xxx` 来查看 ip 地址， 和使用  `host yourdomain.xxx` 得到的结果确实不一样.  这样改一下， 在我自己的设备上没问题了。