### PR TITLE
优化默认脚本模板.

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-#
+
+cd "$(dirname "$0")"
 
 # Import ardnspod functions
-
-. /your_real_path/ardnspod
+. ardnspod
 
 # Combine your token ID and token together as follows
 


### PR DESCRIPTION
这里默认的 `. /your_real_path/ardnspod` 没啥意义， 改成项目 clone 下来更接近可用的状态。