### PR TITLE
Bug fix: 修正跟日志打印有关的两个小问题.

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -37,7 +37,7 @@ export arErrCodeUnchanged=0
 
 arLog() {
 
-    >&2 echo $@
+    >&2 echo "$@"
 
 }
 

--- a/ardnspod
+++ b/ardnspod
@@ -331,7 +331,7 @@ arDdnsUpdate() {
         recordRs=$(arDdnsApi "Record.Ddns" "domain=$1&sub_domain=$2&record_id=$3&record_type=$4&record_line=%e9%bb%98%e8%ae%a4")
     else
         if [ "$5" = "$lastRecordIp" ]; then
-            arLog "> arDdnsUpdate - unchanged: $recordIp" # unchanged event
+            arLog "> arDdnsUpdate - unchanged: $lastRecordIp" # unchanged event
             return $arErrCodeUnchanged
         fi
         recordRs=$(arDdnsApi "Record.Ddns" "domain=$1&sub_domain=$2&record_id=$3&record_type=$4&value=$5&record_line=%e9%bb%98%e8%ae%a4")


### PR DESCRIPTION
- [x] `$recordIp` 没有赋值， 修一下.
- [x] 修正一下 传入 * (比如修改 *.xx.com)时, 这里的 arLog 方法错误打印本地文件的问题.

第二个问题描述一下,  当  `$@` 的值为 `*` 时， shell 里面 `echo *`  会打印出来当前目录下所有文件.  为了避免， 应该写成 `echo "*"`